### PR TITLE
adds srcset element and removes picture element

### DIFF
--- a/templates/partials/partial-overlay-image.php
+++ b/templates/partials/partial-overlay-image.php
@@ -1,48 +1,31 @@
 <?php
 /**
  * FM Overlays Image Template
- * used to create responsive picture element
+ *
+ * implements the srcset attribute in the <img> tag
  */
 
 
-
-
 $image_sizes = Fm_Overlays_Helpers::instance()->get_overlay_image_sizes( $overlay->overlay_content['image_id'] );
-
-
 $classes = 'entry-thumbnail fm-image';
 $alt_text = the_title_attribute( array( 'echo' => false ) );
 $id = 'attachment_' . $overlay->overlay_content['image_id'];
 
 ?>
 
-
 <?php if ( ! empty( $image_sizes ) ) : ?>
-	<picture <?php if ( ! empty( $id ) ) : ?>
+	<div <?php if ( ! empty( $id ) ) : ?>
 		id="<?php echo esc_attr( $id ); ?>"<?php endif; ?>
 		<?php if ( ! empty( $classes ) ) : ?>
 			class="<?php echo esc_attr( $classes ); ?>"
 		<?php endif; ?>>
-		<?php if ( ! empty( $image_sizes['desktop_src'] ) ) : ?>
-			<source
-				srcset="<?php echo esc_url( $image_sizes['desktop_src']['src'] ); ?>"
-				media="(min-width: 768px)">
-		<?php endif; ?>
-		<?php if ( ! empty( $image_sizes['tablet_src'] ) ) : ?>
-			<source
-				srcset="<?php echo esc_url( $image_sizes['tablet_src']['src'] ); ?>"
-				media="(min-width: 640px)">
-		<?php endif; ?>
-		<?php if ( ! empty( $image_sizes['mobile_src'] ) ) : ?>
-			<source
-				srcset="<?php echo esc_url( $image_sizes['mobile_src']['src'] ); ?>"
-				media="(max-width: 639px)">
-			<img
-				srcset="<?php echo esc_url( $image_sizes['mobile_src']['src'] ); ?>"
-				<?php if ( ! empty( $alt_text ) ) : ?>
-					alt="<?php echo esc_attr( $alt_text ); ?>"
-				<?php endif; ?>
-			>
-		<?php endif; ?>
-	</picture>
+		<img srcset="<?php echo ( ! empty( $image_sizes['desktop_src'] ) ? esc_url( $image_sizes['desktop_src']['src'] ) . ' ' . esc_attr( $image_sizes['desktop_src']['width'] ) . 'w, ' : '' ); ?>
+					<?php echo ( ! empty( $image_sizes['tablet_src'] ) ? esc_url( $image_sizes['tablet_src']['src'] ) . ' ' . esc_attr( $image_sizes['tablet_src']['width'] ) . 'w, ' : '' ); ?>
+					<?php echo ( ! empty( $image_sizes['mobile_src'] ) ? esc_url( $image_sizes['mobile_src']['src'] ) . ' ' . esc_attr( $image_sizes['mobile_src']['width'] ) . 'w, ' : '' ); ?>"
+			alt="<?php echo esc_attr( $alt_text ); ?>"
+			sizes="(min-width: 36em) calc(.666 * (100vw - s8em)),
+			   100vw"
+			src="<?php echo esc_url( $image_sizes['mobile_src']['src'] ); ?>"
+		/>
+	</div>
 <?php endif; ?>


### PR DESCRIPTION
Removes picture element and adds in srcset attribute to `<img>` tag  instead.  Using the picture element would have required adding a polyfil to provide universal support where as the `srcset` attribute gracefully falls back on `src`.

This was done in an effort to avoid adding additional dependencies to FM-Overlays plugin
