### PR TITLE
Fix Issue with Conditional Targeting / Improve Priority Sytstem

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,14 +42,14 @@ Overlay conditionals allow the user to target where on the site the overlay will
 
 #### Targeting
 
-Targeting allows the user to target an overlay to a specific page, taxonomy or tag.  Targeting an overlay drastically increases it's priority, explained in detail within [priority systems](### Priority Sytems).
+Targeting allows the user to target an overlay to a specific page, taxonomy or tag.  Targeting an overlay drastically increases its priority, explained in detail within [priority systems](### Priority Sytems).
 
 
 
 
 ### Priority System
 
-Each overlay has a display priority point value calculated from it's conditional settings and menu order.  Each Overlay Priorities are used to determine what overlay should display when more than one is found targeting the current screen.  Each overlay's priority is tallied up and the one with the highest value is then displayed.
+Each overlay has a display priority point value calculated from its conditional settings and menu order.  Each Overlay Priorities are used to determine what overlay should display when more than one is found targeting the current screen.  Each overlay's priority is tallied up and the one with the highest value is then displayed.
 
 #### Point Breakdown
 
@@ -61,13 +61,27 @@ Each overlay has a display priority point value calculated from it's conditional
 
 #### Specificity is prioritized over Menu Order
 
-Conditionals that target specific posts and terms operate on a higher priority than those that target generally.  This is why whenver a targeted conditional is found it's priority is bumped by 200 points.
+Conditionals that target specific posts and terms operate on a higher priority than those that target generally.  This is why whenver a targeted conditional is found its priority is bumped by 200 points.
 
 #### Menu Order
 
 The `menu_order` attribute is utilized in two common scenarios.  The first is to determine priority when a targeted conditional can't be found.    The second is to provide additional specificity and override capabilities to non-targeted overlays.  If no priorities or conditionals have been set on the overlay the *published date* is used as a fallback.
 
+#### Priority Filters
 
+Given that these values will likely need to be changed at some point in time, there are a few filters available to make this easy.
+
+
+#### `fm_overlays_is_specific_priority`
+Used to override the default ***targeted conditional*** value of 200
+
+
+#### `fm_overlays_conditional_matched_priority`
+Used to override the default ***matched conditional*** value of 50
+
+
+#### `fm_overlays_priority_override`
+This filter allows you to completely override the priority of any overlay, ignoring all previous values and conditionals.  It passes two arguments; the current priority `$value` and the instance of the `$overlay`.
 
 
 

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ Requires [Fieldmanager](https://github.com/alleyinteractive/wordpress-fieldmanag
 
 
 
+
 ### Types
 
 fm-overlays currently supports two types of content; either a single **Image** or Rich Text.
@@ -21,32 +22,51 @@ Image overlays utilize both the `srcset` attribute and the js `window.resize` ev
 
 Rich Text overlays are created using the classic **WYSIWYG editor**.
 
+
+
+
 ### Conditionals
 
 Overlay conditionals allow the user to target where on the site the overlay will display.  The following conditionals are currently supported:
 
-- is_home
-- is_front_page
-- *is_category*
-- *has_category*
-- is_single
-- *is_page*
-- *is_tag*
-- *has_tag*
+| Conditional   	| Supports Targeting 	| WP Function     	|
+|---------------	|--------------------	|-----------------	|
+| is_home       	| n/a                	| is_home()       	|
+| is_front_page 	| n/a                	| is_front_page() 	|
+| is_page       	| ✓                  	| is_page()       	|
+| is_single     	| n/a                	| is_single()     	|
+| is_tag        	| ✓                  	| is_tag()        	|
+| has_tag       	| ✓                  	| has_tag()       	|
+| is_category   	| ✓                  	| is_category()   	|
+| has_category  	| ✓                  	| has_category()  	|
 
-Conditionals marked with *italics* allow the user to specifically target a page, category, or tag.
+#### Targeting
 
-
-
-### Priorities
-
-Each overlay has a display priority that can be set using the `menu_order` attribute.  The larger the `menu_order` the higher the display priority.  If no priorities have been set the *published date* is used as a fallback.
+Targeting allows the user to target an overlay to a specific page, taxonomy or tag.  Targeting an overlay drastically increases it's priority, explained in detail within [priority systems](### Priority Sytems).
 
 
 
-### Specificity is prioritized over Menu Order
 
-Conditionals that target specific posts and terms operate on a higher priority than those that target generally.
+### Priority System
+
+Each overlay has a display priority point value calculated from it's conditional settings and menu order.  Each Overlay Priorities are used to determine what overlay should display when more than one is found targeting the current screen.  Each overlay's priority is tallied up and the one with the highest value is then displayed.
+
+#### Point Breakdown
+
+| Condition            |                         Description                         | Operator | Value | Frequency       |
+|----------------------|:-----------------------------------------------------------:|:--------:|:-----:|-----------------|
+| targeted conditional | If an overlay is targeting a specific page, taxonomy or tag |     +    |  200  | per conditional |
+| matched conditional  | If an overlay conditional positively matches current screen |     +    |   50  | per conditional |
+| menu order           | used for manual overrides and additional specificity        |     +    |   X   | per overlay     |
+
+#### Specificity is prioritized over Menu Order
+
+Conditionals that target specific posts and terms operate on a higher priority than those that target generally.  This is why whenver a targeted conditional is found it's priority is bumped by 200 points.
+
+#### Menu Order
+
+The `menu_order` attribute is utilized in two common scenarios.  The first is to determine priority when a targeted conditional can't be found.    The second is to provide additional specificity and override capabilities to non-targeted overlays.  If no priorities or conditionals have been set on the overlay the *published date* is used as a fallback.
+
 
 
 

--- a/php/class-fm-overlays.php
+++ b/php/class-fm-overlays.php
@@ -229,8 +229,6 @@ class Fm_Overlays extends Fm_Overlays_Singleton {
 		// pull in conditional meta array
 		$conditional_meta = get_post_meta( $overlay['post_id'], 'fm_overlays_conditionals', true );
 
-		// var_dump( $conditional_meta );
-
 		if ( ! empty( $overlay['conditionals'] ) ) {
 			foreach ( $overlay['conditionals'] as $key => $condition ) {
 				// Begin with the faith that this condition is false.
@@ -247,8 +245,6 @@ class Fm_Overlays extends Fm_Overlays_Singleton {
 				// note: this will always be set as long as $overlay['conditionals'] is not empty
 				$cond_func = $condition['condition_select'];
 
-				// var_dump( $condition,  $key );
-
 				// get the associated arguments meta field
 				$cond_arg_key = $this->_get_associated_conditional_arg( $condition );
 				if ( ! empty( $cond_arg_key ) ) {
@@ -262,9 +258,6 @@ class Fm_Overlays extends Fm_Overlays_Singleton {
 					$cond_str_prefix = 'not-';
 				}
 
-
-				var_dump( $cond_func, $cond_arg );
-
 				/**
 				 * Run conditional function that is passed
 				 * from the Fieldmanager select options.
@@ -274,8 +267,6 @@ class Fm_Overlays extends Fm_Overlays_Singleton {
 				} elseif ( ! empty( $cond_arg ) && true === $affirmative_condition ) {
 					$result = call_user_func( $cond_func, $cond_arg );
 				}
-
-				var_dump( $result );
 
 				/**
 				 * Verify the validity of the condition based on the function call result
@@ -311,8 +302,6 @@ class Fm_Overlays extends Fm_Overlays_Singleton {
 		// Begin by assuming there are no specially prioritized overlays.
 		$prioritization_basis = 'date';
 		$prioritized_overlays = array();
-
-		var_dump($unprioritized_overlays);
 
 		foreach ( $unprioritized_overlays as $overlay ) {
 

--- a/php/class-fm-overlays.php
+++ b/php/class-fm-overlays.php
@@ -312,23 +312,26 @@ class Fm_Overlays extends Fm_Overlays_Singleton {
 			$is_specific = false;
 			$priority = 0;
 
-			// loop through each conditional attached to the overlay
-			foreach ( $overlay['conditionals'] as $condition ) {
-				$cond_arg_key = $this->_get_associated_conditional_arg( $condition );
-				// check if condition contains target specificity
-				if ( isset( $condition[ $cond_arg_key ] ) ) {
-					$is_specific = true;
+			// act on conditionals if we have them
+			if ( ! empty( $overlay['conditionals'] ) &&  is_array( $overlay['conditionals'] ) ) {
+				// loop through each conditional attached to the overlay
+				foreach ( $overlay['conditionals'] as $condition ) {
+					$cond_arg_key = $this->_get_associated_conditional_arg( $condition );
+					// check if condition contains target specificity
+					if ( isset( $condition[ $cond_arg_key ] ) ) {
+						$is_specific = true;
+					}
 				}
-			}
 
-			// specificity adds 200 to the priority weight of the overlay
-			if ( $is_specific ) {
-				$priority += '200';
-			}
+				// specificity adds 200 to the priority weight of the overlay
+				if ( $is_specific ) {
+					$priority += '200';
+				}
 
-			// each matching conditionals adds 50 to the priority weight
-			if ( ! empty( $condition['conditionals_matched'] ) && is_int( $condition['conditionals_matched'] ) ) {
-				$priority += $condition['conditionals_matched'] * 50;
+				// each matching conditionals adds 50 to the priority weight
+				if ( ! empty( $condition['conditionals_matched'] ) && is_int( $condition['conditionals_matched'] ) ) {
+					$priority += $condition['conditionals_matched'] * 50;
+				}
 			}
 
 			// Add in the menu order value to our overall priority

--- a/php/class-fm-overlays.php
+++ b/php/class-fm-overlays.php
@@ -118,7 +118,6 @@ class Fm_Overlays extends Fm_Overlays_Singleton {
 				 */
 				$targeted_conditionals = $this->process_overlay_conditions( $overlay );
 
-
 				/**
 				 * Verify the validity of the condition based on the function call result
 				 * and the affirmation/negation of the condition.
@@ -251,7 +250,6 @@ class Fm_Overlays extends Fm_Overlays_Singleton {
 					$cond_arg = isset( $conditional_meta[ $key ][ $cond_arg_key ] ) ? $conditional_meta[ $key ][ $cond_arg_key ] : '';
 				}
 
-
 				// If the condition is negated, then we need to skip the condition.
 				if ( isset( $condition['condition_negation'] ) && 'negated' === $condition['condition_negation'] ) {
 					$affirmative_condition = false;
@@ -337,7 +335,6 @@ class Fm_Overlays extends Fm_Overlays_Singleton {
 			$priority += ( ! empty( $overlay['priority'] ) ) ? $overlay['priority'] : 0;
 
 			$prioritized_overlays[ $priority ][] = $overlay;
-
 
 			// if there is a set menu order, then base the prioritization
 			// on menu_order instead of post date.

--- a/php/class-fm-overlays.php
+++ b/php/class-fm-overlays.php
@@ -57,7 +57,9 @@ class Fm_Overlays extends Fm_Overlays_Singleton {
 		 * Limit overlays query to 50 posts by default.
 		 * Ideally, any usecase would have far less than 50 active overlays.
 		 *
-		 * At any rate, use this filter to change limit.
+		 * @since 1.0.0
+		 *
+		 * @param int numberposts controls the number of posts retrieved by get_posts
 		 */
 		$args = array(
 			'post_type' => $fm_overlays_post_type,
@@ -323,22 +325,54 @@ class Fm_Overlays extends Fm_Overlays_Singleton {
 					}
 				}
 
-				// specificity adds 200 to the priority weight of the overlay
+				// check if the overlay is specifically targeted to a page, tax, term, or tag
 				if ( $is_specific ) {
-					$priority += apply_filters( 'fm_overlays_is_specific_priority', 200 );
+
+					/**
+					 * Filter: fm_overlays_is_specific_priority
+					 *
+					 * Edit the value applied to priority when an overlay is specifically targeted.
+					 * Defaults to 200.
+					 *
+					 * @since 1.0.0
+					 *
+					 * @param float $priority 	weight of targeted overlays.
+					 */
+					$priority += floatval( apply_filters( 'fm_overlays_is_specific_priority', 200 ) );
 				}
 
 				// each matching conditionals adds 50 to the priority weight
 				if ( ! empty( $condition['conditionals_matched'] ) && is_int( $condition['conditionals_matched'] ) ) {
-					$priority += $condition['conditionals_matched'] * apply_filters( 'fm_overlays_conditional_matched_priority', 50 );
+
+					/**
+					 * Filter: fm_overlays_conditional_matched_priority
+					 *
+					 * Edit the value addded to priority for each overlay conditional that returns true.
+					 * Defaults to 50.
+					 *
+					 * @since 1.0.0
+					 *
+					 * @param float $priority 	weight of matched conditionals.
+					 */
+					$priority += $condition['conditionals_matched'] * floatval( apply_filters( 'fm_overlays_conditional_matched_priority', 50 ) );
 				}
 			}
 
 			// Add in the menu order value to our overall priority
 			$priority += ( ! empty( $overlay['priority'] ) ) ? $overlay['priority'] : 0;
 
-			// Add a filter to override priority of any overlay
-			$priority = apply_filters( 'fm_overlays_priority_override', $priority, $overlay );
+			/**
+			 * Filter: fm_overlays_priority_override
+			 *
+			 * Completely override the priority value of a specific overlay.
+			 * The current overlay is passed as the second argument.
+			 *
+			 * @since 1.0.0
+			 *
+			 * @param float $priority  	current priority value after calculating conditionals and menu order.
+			 * @param object $overlay 	Instance of overlay post object being prioritized
+			 */
+			$priority = floatval( apply_filters( 'fm_overlays_priority_override', $priority, $overlay ) );
 
 			$prioritized_overlays[ $priority ][] = $overlay;
 

--- a/php/class-fm-overlays.php
+++ b/php/class-fm-overlays.php
@@ -325,17 +325,20 @@ class Fm_Overlays extends Fm_Overlays_Singleton {
 
 				// specificity adds 200 to the priority weight of the overlay
 				if ( $is_specific ) {
-					$priority += '200';
+					$priority += apply_filters( 'fm_overlays_is_specific_priority', 200 );
 				}
 
 				// each matching conditionals adds 50 to the priority weight
 				if ( ! empty( $condition['conditionals_matched'] ) && is_int( $condition['conditionals_matched'] ) ) {
-					$priority += $condition['conditionals_matched'] * 50;
+					$priority += $condition['conditionals_matched'] * apply_filters( 'fm_overlays_conditional_matched_priority', 50 );
 				}
 			}
 
 			// Add in the menu order value to our overall priority
 			$priority += ( ! empty( $overlay['priority'] ) ) ? $overlay['priority'] : 0;
+
+			// Add a filter to override priority of any overlay
+			$priority = apply_filters( 'fm_overlays_priority_override', $priority, $overlay );
 
 			$prioritized_overlays[ $priority ][] = $overlay;
 

--- a/php/class-fm-overlays.php
+++ b/php/class-fm-overlays.php
@@ -318,7 +318,7 @@ class Fm_Overlays extends Fm_Overlays_Singleton {
 				// check if condition contains target specificity
 				if ( isset( $condition[ $cond_arg_key ] ) ) {
 					$is_specific = true;
- 				}
+				}
 			}
 
 			// specificity adds 200 to the priority weight of the overlay


### PR DESCRIPTION
This PR refactors how overlay priorities are handled, as well as fixing the issue where targeted overlays are ignored when determining which overlay should be display to user.  

The issue with targeted overlays not working stemmed from the fact that the meta key that was being passed into `get_post_meta` was invalid & we infact needed to loop through the conditional meta data to determine if the overlay was specifically targeted to a page or not.  This functionality was added to the `prioritize_overlays` function.

The priority system now uses a point value system, calculating an overlays priority based on the overlays configuration.
#### Point Breakdown

| Condition | Description | Operator | Value | Frequency |
| --- | :-: | :-: | :-: | --- |
| targeted conditional | If an overlay is targeting a specific page, taxonomy or tag | + | 200 | per conditional |
| matched conditional | If an overlay conditional positively matches current screen | + | 50 | per conditional |
| menu order | used for manual overrides and additional specificity | + | X | per overlay |

This break down has been added to the readme.
